### PR TITLE
update(26879):  showing sim card missing error on sample app

### DIFF
--- a/TwilioVerifySNADemo/Screens/PhoneNumber/PhoneNumberViewController.swift
+++ b/TwilioVerifySNADemo/Screens/PhoneNumber/PhoneNumberViewController.swift
@@ -391,7 +391,7 @@ extension PhoneNumberViewController {
         let networkInfo = CTTelephonyNetworkInfo()
         let carriers = networkInfo.serviceSubscriberCellularProviders ?? [:]
 
-        let validCarriers = carriers.values.compactMap() {
+        let validCarriers = carriers.values.compactMap {
             $0.isoCountryCode
         }
 


### PR DESCRIPTION
## Ticket
- [26879]

## Description
-  showing sim card missing error on sample app. This is already being handled on the SDK, although for the sample app flow, the backend call is done first so it causes an unexpected error message.

## Screenshot

![image](https://user-images.githubusercontent.com/14830877/188695598-1ebeaef5-5a57-4047-add8-aeefb568c4c8.png)
