### PR TITLE
feat(33235): Create custom getaddrinfo to force DNS resolution over cellular network.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# 0.0.3 (26–12-2023)
+# 0.0.5 (02–02-2024)
+
+### Improvements
+
+- Introduce custom getaddrinfo to ensure DNS resolution exclusively through the cellular network
+
+# 0.0.4 (01–02-2024)
+
+### Fixes
+
+- Append buffer from HTTP request to the responseData.
+
+# 0.0.3 (12–26-2023)
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ During the current phase of this project, we only support SPM. We have plans to 
 dependencies: [
     .package(
         url: "https://github.com/twilio/twilio-verify-sna-ios.git",
-        .upToNextMajor(from: "0.0.4")
+        .upToNextMajor(from: "0.0.5")
     )
 ]
 ```

--- a/SNASources/CellularGetAddrinfo.m
+++ b/SNASources/CellularGetAddrinfo.m
@@ -1,0 +1,128 @@
+//
+//  CellularGetAddrinfo.m
+//
+//
+//  Created by Alejandro Orozco Builes on 24/01/24.
+//
+
+#import <Foundation/Foundation.h>
+#import "CellularGetAddrinfo.h"
+#include <net/if.h>
+#import <netdb.h>
+
+int global_port;
+
+int cellular_getaddrinfo(const char *nodename, const char *servname,
+                       const struct addrinfo *hints, struct addrinfo **res,
+                       DNSServiceRef sdRef, DNSServiceFlags flags,
+                       DNSServiceProtocol protocol) {
+    sa_family_t family = AF_INET;
+    
+    if (protocol == kDNSServiceProtocol_IPv4) {
+        family = AF_INET;
+    } else if (protocol == kDNSServiceProtocol_IPv6) {
+        family = AF_INET6;
+    }
+
+    // Get the cellular network interface index
+    unsigned int interfaceIndex = 0;
+    struct ifaddrs *interfaces = NULL;
+    if (getifaddrs(&interfaces) == 0) {
+        for (struct ifaddrs *ifa = interfaces; ifa != NULL; ifa = ifa->ifa_next) {
+            if (ifa->ifa_addr->sa_family == family &&
+                strcmp(ifa->ifa_name, "pdp_ip0") == 0 &&
+                ifa->ifa_flags & IFF_UP) {
+                interfaceIndex = if_nametoindex(ifa->ifa_name);
+                break;
+            }
+        }
+        freeifaddrs(interfaces);
+        interfaces = NULL;
+    }
+
+    // Check if cellular interface index found
+    if (interfaceIndex == 0) {
+        NSLog(@"Error: Could not find cellular network interface");
+        return 1; // Indicate general failure
+    }
+
+    // Set the global port number
+    if (strcmp(servname, "http") == 0) {
+        global_port = 80;
+    } else if (strcmp(servname, "https") == 0) {
+        global_port = 443;
+    } else {
+        global_port = atoi(servname);
+    }
+
+    // Use DNSServiceGetAddrInfo with cellular interface index
+    DNSServiceErrorType err = DNSServiceGetAddrInfo(&sdRef, flags, interfaceIndex, protocol,
+                                                      nodename, cellular_getaddrinfo_callback, res);
+
+    DNSServiceProcessResult(sdRef);
+    DNSServiceRefDeallocate(sdRef);
+
+    // Convert DNSServiceErrorType to POSIX error code
+    if (err == kDNSServiceErr_NoError) {
+        return 0;
+    } else {
+        return htonl(err); // Map DNSService errors to POSIX errors
+    }
+}
+
+void cellular_getaddrinfo_callback(DNSServiceRef sdRef, DNSServiceFlags flags,
+                                 uint32_t interfaceIndex, DNSServiceErrorType err,
+                                 const char *hostname, const struct sockaddr *address,
+                                 uint32_t ttl, void *context) {
+    // Handle the results or errors received in the callback
+    if (err == kDNSServiceErr_NoError) {
+
+        struct addrinfo **results = (struct addrinfo **)context;
+
+        *results = (struct addrinfo *)malloc(sizeof(struct addrinfo));
+        if (*results == NULL) {
+            NSLog(@"Error: Could not allocate memory for results");
+            return;
+        }
+        memset(*results, 0, sizeof(struct addrinfo));
+
+        // Determine the size of the address structure
+        size_t addrSize = 0;
+        if (address->sa_family == AF_INET) {
+            addrSize = sizeof(struct sockaddr_in);
+        } else if (address->sa_family == AF_INET6) {
+            addrSize = sizeof(struct sockaddr_in6);
+        } else {
+            NSLog(@"Error: Unsupported address family");
+            free(*results);
+            *results = NULL;
+            return;
+        }
+
+        (*results)->ai_addr = (struct sockaddr *)malloc(addrSize);
+        if ((*results)->ai_addr == NULL) {
+            NSLog(@"Error: Could not allocate memory for ai_addr");
+            free(*results);
+            *results = NULL;
+            return;
+        }
+
+        memcpy((*results)->ai_addr, address, addrSize);
+
+        (*results)->ai_family = address->sa_family;
+        (*results)->ai_socktype = SOCK_STREAM; // Set to SOCK_STREAM for TCP
+        (*results)->ai_protocol = IPPROTO_TCP; // Set to IPPROTO_TCP for TCP
+        (*results)->ai_addrlen = (socklen_t)addrSize;
+
+        // If the address is IPv4 or IPv6, set the port number
+        if (address->sa_family == AF_INET) {
+            ((struct sockaddr_in *)(*results)->ai_addr)->sin_port = htons(global_port);
+        } else if (address->sa_family == AF_INET6) {
+            ((struct sockaddr_in6 *)(*results)->ai_addr)->sin6_port = htons(global_port);
+        }
+    } else {
+        NSLog(@"DNSServiceGetAddrInfo failed: %d", err);
+        struct addrinfo **results = (struct addrinfo **)context;
+        *results = NULL;
+    }
+}

--- a/SNASources/include/CellularGetAddrinfo.h
+++ b/SNASources/include/CellularGetAddrinfo.h
@@ -1,0 +1,23 @@
+//
+//  CellularGetAddrinfo.h
+//
+//
+//  Created by Alejandro Orozco Builes on 24/01/24.
+//
+
+#import <Foundation/Foundation.h>
+#import <dns_sd.h>
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+
+// Cellular GetAddrInfo forces the DNS resolution through cellular network
+int cellular_getaddrinfo(const char *nodename, const char *servname,
+                       const struct addrinfo *hints, struct addrinfo **res,
+                       DNSServiceRef sdRef, DNSServiceFlags flags,
+                       DNSServiceProtocol protocol);
+
+// DNSServiceGetAddrInfoReply Callback retrieve the DNS resolution
+void cellular_getaddrinfo_callback(DNSServiceRef sdRef, DNSServiceFlags flags,
+                                 uint32_t interfaceIndex, DNSServiceErrorType err,
+                                 const char *hostname, const struct sockaddr *address,
+                                 uint32_t ttl, void *context);

--- a/Sources/Domain/TwilioVerifySNA/TwilioVerifySNASession.swift
+++ b/Sources/Domain/TwilioVerifySNA/TwilioVerifySNASession.swift
@@ -130,9 +130,9 @@ final class TwilioVerifySNASession: TwilioVerifySNA {
 
         DispatchQueue.main.asyncAfter(
             deadline: .now() + Constants.waitForConnectionTimeInSeconds
-        ) {
-            self.waitForConnectionAccumulatedTime += Constants.waitForConnectionTimeInSeconds
-            self.processURL(url, onComplete: completionHandler)
+        ) { [weak self] in
+            self?.waitForConnectionAccumulatedTime += Constants.waitForConnectionTimeInSeconds
+            self?.processURL(url, onComplete: completionHandler)
         }
     }
 

--- a/Sources/TwilioVerifySNAConfig.swift
+++ b/Sources/TwilioVerifySNAConfig.swift
@@ -20,5 +20,5 @@
 import Foundation
 
 public struct TwilioVerifySNAConfig {
-    public static let version = "0.0.4"
+    public static let version = "0.0.5"
 }

--- a/TwilioVerifySNADemo/Screens/PhoneNumber/PhoneNumberViewController.swift
+++ b/TwilioVerifySNADemo/Screens/PhoneNumber/PhoneNumberViewController.swift
@@ -199,10 +199,10 @@ final class PhoneNumberViewController: UIViewController {
              handle the response on the main thread if we are going to update the UI
              */
 
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
                 guard success else {
                     // if the validation fails, you can customize your app the behavior here
-                    self.performSegue(
+                    self?.performSegue(
                         withIdentifier: Segues.verificationErrorScreen.rawValue,
                         sender: nil
                     )
@@ -210,7 +210,7 @@ final class PhoneNumberViewController: UIViewController {
                 }
 
                 // if the validation succeed, you can customize your app the behavior here
-                self.performSegue(
+                self?.performSegue(
                     withIdentifier: Segues.verificationSuccessfulScreen.rawValue,
                     sender: nil
                 )
@@ -306,16 +306,15 @@ extension PhoneNumberViewController {
 
     /// Not required for the SDK implementation.
     private func showGenericError(_ error: String? = nil) {
-        let alert = UIAlertController(
-            title: "Error",
-            message: error ?? "Unexpected error",
-            preferredStyle: .alert
-        )
+        DispatchQueue.main.async { [weak self] in
+            let alert = UIAlertController(
+                title: "Error",
+                message: error ?? "Unexpected error",
+                preferredStyle: .alert
+            )
 
-        alert.addAction(UIAlertAction(title: "Accept", style: .cancel))
-
-        DispatchQueue.main.async {
-            self.present(alert, animated: true)
+            alert.addAction(UIAlertAction(title: "Accept", style: .cancel))
+            self?.present(alert, animated: true)
         }
     }
 
@@ -399,4 +398,4 @@ extension PhoneNumberViewController {
 }
 
 /// Not required for the SDK implementation.
-private let sampleAppVersion = "0.0.3"
+private let sampleAppVersion = "0.0.5"


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify SNA. Please consider this template for your PR -->
<!-- Title format: [Ticket Number/Issue Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->

<!-- Ticket: Please add the ticket number or the Github issue number according to your case -->

## Ticket

- [33235]

## Github Issue

## Description

- Discovered an issue with the getaddrinfo API, where it consistently favored WiFi over cellular networks. This resulted in complications for IPv6 hostnames, particularly on ISPs without IPv6 support. The resolution involves transitioning to a different low-level API, DNSServiceGetAddrInfo, allowing explicit specification of the network and IP version for more reliable DNS resolution.

<!-- Commit message: Use Conventional commits https://www.conventionalcommits.org/en/v1.0.0/-->

## Commit message

- feat(33235): Create custom getaddrinfo to force DNS resolution over cellular network.

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->


https://github.com/twilio/twilio-verify-sna-ios/assets/4898461/7595d0f7-7540-46fe-9253-f78a047590d8


https://github.com/twilio/twilio-verify-sna-ios/assets/4898461/fb6249b4-44ab-4881-a1ed-f90cb4760c90



## Screenshot

<!-- Testing: Please check all that apply -->

## Testing

- [ ] Added unit tests
- [x] Ran unit tests successfully
- [x] Added documentation for public APIs and/or Wiki
