### PR TITLE
fix: Resolve Keep-Alive Redirect Handling and Add Default Path for HTTP/1.1 Requests

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and analyse default scheme using xcodebuild command
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - name: Checkout

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.0.9 (18–12-2024)
+
+### Improvements
+
+- Fixed Redirect Handling with Keep-Alive Connections: Resolved an issue where redirects could fail due to persistent keep-alive connections. The fix ensures the connection is proactively closed upon detecting a redirection in the buffer, preventing inconsistencies and ensuring smooth redirection handling.
+- Added Default Path for HTTP/1.1 Requests: Introduced a default path ("/") for HTTP/1.1 requests to ensure compatibility with servers when no explicit path is specified in the request URL.
+
 # 0.0.8 (12–06-2024)
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ During the current phase of this project, we only support SPM. We have plans to 
 dependencies: [
     .package(
         url: "https://github.com/twilio/twilio-verify-sna-ios.git",
-        .upToNextMajor(from: "0.0.8")
+        .upToNextMajor(from: "0.0.9")
     )
 ]
 ```

--- a/SNASources/include/SocketAddress.h
+++ b/SNASources/include/SocketAddress.h
@@ -23,6 +23,7 @@
 #define SocketAddress_h
 
 #import <Foundation/Foundation.h>
+#import <SystemConfiguration/SystemConfiguration.h>
 
 typedef struct sockaddr *sockaddr_t;
 

--- a/Sources/TwilioVerifySNAConfig.swift
+++ b/Sources/TwilioVerifySNAConfig.swift
@@ -20,5 +20,5 @@
 import Foundation
 
 public struct TwilioVerifySNAConfig {
-    public static let version = "0.0.8"
+    public static let version = "0.0.9"
 }

--- a/TwilioVerifySNADemo/Screens/PhoneNumber/PhoneNumberViewController.swift
+++ b/TwilioVerifySNADemo/Screens/PhoneNumber/PhoneNumberViewController.swift
@@ -398,4 +398,4 @@ extension PhoneNumberViewController {
 }
 
 /// Not required for the SDK implementation.
-private let sampleAppVersion = "0.0.8"
+private let sampleAppVersion = "0.0.9"

--- a/TwilioVerifySNADemo/TwilioVerifySNADemo.xcodeproj/project.pbxproj
+++ b/TwilioVerifySNADemo/TwilioVerifySNADemo.xcodeproj/project.pbxproj
@@ -417,7 +417,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.TwilioVerifySNADemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -448,7 +448,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.TwilioVerifySNADemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify SNA. Please consider this template for your PR -->
<!-- Title format: [Ticket Number/Issue Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->

<!-- Ticket: Please add the ticket number or the Github issue number according to your case -->

## Ticket

- [#####]

## Github Issue

- ISSUE-

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->

## Description

- fix: resolve redirect issue caused by keep-alive connection by proactively closing the connection when a redirection is detected in the buffer.
- fix: Add default path for HTTP 1.1 requests when no path is explicitly defined.

<!-- Commit message: Use Conventional commits https://www.conventionalcommits.org/en/v1.0.0/-->

## Commit message

-

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->

## Screenshot

<!-- Testing: Please check all that apply -->

## Testing

- [ ] Added unit tests
- [x] Ran unit tests successfully
- [x] Added documentation for public APIs and/or Wiki
